### PR TITLE
Mute external speakers when headphones are connected

### DIFF
--- a/branches/zdev/Parser.cpp
+++ b/branches/zdev/Parser.cpp
@@ -4502,6 +4502,40 @@ void VoodooHDADevice::hpSwitchHandler(FunctionGroup *funcGroup, int nid, UInt32 
 			}
 		}
 	}
+	/* (Un)Mute output pins from other associations (e.g. external speakers). */
+	for (int otherAssoc = 0; otherAssoc < funcGroup->audio.numAssocs; otherAssoc++) {
+		if (otherAssoc == assocsNum)
+			continue;
+		if (assocs[otherAssoc].dir != HDA_CTL_OUT)
+			continue;
+		if (assocs[otherAssoc].hpredir >= 0)
+			continue;
+		for (int j = 0; j < 16; j++) {
+			int pin = assocs[otherAssoc].pins[j];
+			if (pin <= 0)
+				continue;
+			control = audioCtlAmpGet(funcGroup, pin, HDA_CTL_IN, -1, 1);
+			if (control && control->mute) {
+				val = (res != 0) ? 1 : 0;
+				if (val == (UInt32)control->forcemute)
+					continue;
+				control->forcemute = val;
+				audioCtlAmpSet(control, HDA_AMP_MUTE_DEFAULT, HDA_AMP_VOL_DEFAULT, HDA_AMP_VOL_DEFAULT);
+				continue;
+			}
+			widget = widgetGet(funcGroup, pin);
+			if (widget && (widget->type == HDA_PARAM_AUDIO_WIDGET_CAP_TYPE_PIN_COMPLEX)) {
+				if (res != 0)
+					val = widget->pin.ctrl & ~HDA_CMD_SET_PIN_WIDGET_CTRL_OUT_ENABLE;
+				else
+					val = widget->pin.ctrl | HDA_CMD_SET_PIN_WIDGET_CTRL_OUT_ENABLE;
+				if (val != widget->pin.ctrl) {
+					widget->pin.ctrl = val;
+					sendCommand(HDA_CMD_SET_PIN_WIDGET_CTRL(cad, widget->nid, widget->pin.ctrl), cad);
+				}
+			}
+		}
+	}
 }
 
 void VoodooHDADevice::switchHandler(FunctionGroup *funcGroup, bool first)

--- a/tranc/Parser.cpp
+++ b/tranc/Parser.cpp
@@ -4715,6 +4715,40 @@ void VoodooHDADevice::hpSwitchHandler(FunctionGroup *funcGroup, int nid, UInt32 
 			}
 		}
 	}
+	/* (Un)Mute output pins from other associations (e.g. external speakers). */
+	for (int otherAssoc = 0; otherAssoc < funcGroup->audio.numAssocs; otherAssoc++) {
+		if (otherAssoc == assocsNum)
+			continue;
+		if (assocs[otherAssoc].dir != HDA_CTL_OUT)
+			continue;
+		if (assocs[otherAssoc].hpredir >= 0)
+			continue;
+		for (int j = 0; j < 16; j++) {
+			int pin = assocs[otherAssoc].pins[j];
+			if (pin <= 0)
+				continue;
+			control = audioCtlAmpGet(funcGroup, pin, HDA_CTL_IN, -1, 1);
+			if (control && control->mute) {
+				val = (res != 0) ? 1 : 0;
+				if (val == (UInt32)control->forcemute)
+					continue;
+				control->forcemute = val;
+				audioCtlAmpSet(control, HDA_AMP_MUTE_DEFAULT, HDA_AMP_VOL_DEFAULT, HDA_AMP_VOL_DEFAULT);
+				continue;
+			}
+			widget = widgetGet(funcGroup, pin);
+			if (widget && (widget->type == HDA_PARAM_AUDIO_WIDGET_CAP_TYPE_PIN_COMPLEX)) {
+				if (res != 0)
+					val = widget->pin.ctrl & ~HDA_CMD_SET_PIN_WIDGET_CTRL_OUT_ENABLE;
+				else
+					val = widget->pin.ctrl | HDA_CMD_SET_PIN_WIDGET_CTRL_OUT_ENABLE;
+				if (val != widget->pin.ctrl) {
+					widget->pin.ctrl = val;
+					sendCommand(HDA_CMD_SET_PIN_WIDGET_CTRL(cad, widget->nid, widget->pin.ctrl), cad);
+				}
+			}
+		}
+	}
 }
 
 void VoodooHDADevice::switchHandler(FunctionGroup *funcGroup, bool first)


### PR DESCRIPTION
## Problem

`hpSwitchHandler` only muted/unmuted pins within the same HDA association as the HP pin (typically the built-in speaker). Pins in other output associations — e.g. externally connected speakers on a LINE_OUT port — were left untouched, so plugging in headphones would not silence them.

## Solution

After the existing per-association pin loop, add a second loop that iterates all other `HDA_CTL_OUT` associations without an HP redirect, and mutes/unmutes their pins in sync with headphone insertion/removal.

The logic mirrors the existing mute path:
- if the pin has a muter amp → use `forcemute`
- otherwise → toggle `HDA_CMD_SET_PIN_WIDGET_CTRL_OUT_ENABLE`

Applied to both `branches/zdev/Parser.cpp` and `tranc/Parser.cpp`.

## Test plan

- [ ] Plug headphones in — built-in speaker and external speakers both go silent
- [ ] Unplug headphones — both outputs restore
- [ ] Verify no regression when no external speakers are connected

🤖 Generated with [Claude Code](https://claude.com/claude-code)