### PR TITLE
Mute iGain/iMix by default to prevent startup pop

### DIFF
--- a/tranc/Tables.c
+++ b/tranc/Tables.c
@@ -535,10 +535,10 @@ const MixerValueName MixerValueNamesBind[SOUND_MIXER_NRDEVICES] = {
 {"Line",	SOUND_MIXER_LINE, 75},		// (was 75) SOUND_MIXER_LINE
 {"Mic",		SOUND_MIXER_MIC, 50},		// SOUND_MIXER_MIC
 {"CD",		SOUND_MIXER_CD, 90},	// SOUND_MIXER_CD
-{"iMix",	SOUND_MIXER_IMIX, 0},		// 0: input monitor muted by default to prevent startup pop
+{"iMix",	SOUND_MIXER_IMIX, 70},		// 70: main PCM playback path (NID 2→NID 12→speaker) — must not be 0
 {"AltPCM",	SOUND_MIXER_ALTPCM, 30},		// [?] SOUND_MIXER_ALTPCM
 {"Rec",		SOUND_MIXER_RECLEV, 75},		// SOUND_MIXER_RECLEV
-{"iGain",	SOUND_MIXER_IGAIN, 0},		// 0: input monitor muted by default to prevent startup pop
+{"iGain",	SOUND_MIXER_IGAIN, 0},		// 0: loopback path (NID 11→NID 12) muted to prevent startup pop (was 80)
 {"oGain",	SOUND_MIXER_OGAIN, 50},		// SOUND_MIXER_OGAIN
 {"Line1",	SOUND_MIXER_LINE1, 30},		// (was 75) SOUND_MIXER_LINE1
 {"Line2",	SOUND_MIXER_LINE2, 10},		// [?] SOUND_MIXER_LINE2

--- a/tranc/Tables.c
+++ b/tranc/Tables.c
@@ -535,10 +535,10 @@ const MixerValueName MixerValueNamesBind[SOUND_MIXER_NRDEVICES] = {
 {"Line",	SOUND_MIXER_LINE, 75},		// (was 75) SOUND_MIXER_LINE
 {"Mic",		SOUND_MIXER_MIC, 50},		// SOUND_MIXER_MIC
 {"CD",		SOUND_MIXER_CD, 90},	// SOUND_MIXER_CD
-{"iMix",	SOUND_MIXER_IMIX, 70},		// [?] SOUND_MIXER_IMIX
+{"iMix",	SOUND_MIXER_IMIX, 0},		// 0: input monitor muted by default to prevent startup pop
 {"AltPCM",	SOUND_MIXER_ALTPCM, 30},		// [?] SOUND_MIXER_ALTPCM
 {"Rec",		SOUND_MIXER_RECLEV, 75},		// SOUND_MIXER_RECLEV
-{"iGain",	SOUND_MIXER_IGAIN, 80},		// SOUND_MIXER_IGAIN
+{"iGain",	SOUND_MIXER_IGAIN, 0},		// 0: input monitor muted by default to prevent startup pop
 {"oGain",	SOUND_MIXER_OGAIN, 50},		// SOUND_MIXER_OGAIN
 {"Line1",	SOUND_MIXER_LINE1, 30},		// (was 75) SOUND_MIXER_LINE1
 {"Line2",	SOUND_MIXER_LINE2, 10},		// [?] SOUND_MIXER_LINE2


### PR DESCRIPTION
## Problem

A pop/click occurs in speakers at startup (and on wake) due to the InputMonitor (loopback) path.

The InputMonitor feeds mic/line inputs back to the speaker output via the Input Mix widget (e.g. NID 11 on Realtek ALC887/897). The previous default for `iGain` (SOUND_MIXER_IGAIN) was 80.

`audioCtlCommit()` correctly mutes the loopback control during init, but `mixerSetDefaults()` immediately unmutes it back to 80% — into an already-active output chain — causing an audible pop.

`DisableInputMonitor` worked around this on Realtek/IDT/AD by physically removing the loopback widget (NID 11) from the graph, so IGAIN was never mapped. It doesn't help on other codecs.

## Solution

Set `iGain` default to 0 in `tranc/Tables.c`:

```c
{"iMix",  SOUND_MIXER_IMIX, 70},  // unchanged — main PCM path (DAC NID 2 → mixer NID 12 → speaker)
{"iGain", SOUND_MIXER_IGAIN, 0},  // was 80 → loopback path (NID 11 → NID 12) muted at startup
```

The loopback stays muted after startup. Users who want loopback/karaoke can raise `iGain` manually in the preference panel.

`DisableInputMonitor` remains useful for codecs where the loopback widget has no OSS control mapping.

## Test plan

- [ ] Boot — no pop without `DisableInputMonitor`
- [ ] Wake from sleep — no pop
- [ ] Audio playback unaffected (iMix stays at 70)
- [ ] iGain can be raised manually for loopback/karaoke

🤖 Generated with [Claude Code](https://claude.com/claude-code)