### PR TITLE
Fix HP_OUT in standalone association selected as default output when disconnected

### DIFF
--- a/branches/zdev/Parser.cpp
+++ b/branches/zdev/Parser.cpp
@@ -4612,6 +4612,47 @@ void VoodooHDADevice::switchHandler(FunctionGroup *funcGroup, bool first)
 		}
 		assocs[assocNum].dirty |= res;
 	}
+	/* Handle HP_OUT pins in standalone associations (hpredir < 0):
+	 * read presence detection and update HPHN_ENABLE so that macOS does
+	 * not select disconnected headphones as the default output. */
+	for (int nid = funcGroup->startNode; nid < funcGroup->endNode; nid++) {
+		widget = widgetGet(funcGroup, nid);
+		if (!widget || (widget->enable == 0) || (widget->type != HDA_PARAM_AUDIO_WIDGET_CAP_TYPE_PIN_COMPLEX))
+			continue;
+		if (HDA_PARAM_PIN_CAP_PRESENCE_DETECT_CAP(widget->pin.cap) == 0)
+			continue;
+		if ((HDA_CONFIG_DEFAULTCONF_MISC(widget->pin.config) & 1) != 0)
+			continue;
+		if ((widget->pin.config & HDA_CONFIG_DEFAULTCONF_DEVICE_MASK) != HDA_CONFIG_DEFAULTCONF_DEVICE_HP_OUT)
+			continue;
+		assocNum = widget->bindAssoc;
+		if (assocs[assocNum].hpredir >= 0)
+			continue; /* already handled by the main loop above */
+		res = sendCommand(HDA_CMD_GET_PIN_SENSE(cad, nid), cad);
+		res = HDA_CMD_GET_PIN_SENSE_PRESENCE_DETECT(res);
+		if (funcGroup->audio.quirks & HDA_QUIRK_SENSEINV)
+			res ^= 1;
+		if (!first && (widget->sense == res))
+			continue;
+		widget->sense = res;
+		logMsg("HP standalone pin sense: cad %d nid=%d res=%d\n", (int)cad, (int)nid, (int)res);
+		/* Enable headphone amplifier only when headphones are present. */
+		UInt32 val;
+		if (res != 0)
+			val = widget->pin.ctrl | HDA_CMD_SET_PIN_WIDGET_CTRL_HPHN_ENABLE;
+		else
+			val = widget->pin.ctrl & ~HDA_CMD_SET_PIN_WIDGET_CTRL_HPHN_ENABLE;
+		if (val != widget->pin.ctrl) {
+			widget->pin.ctrl = val;
+			sendCommand(HDA_CMD_SET_PIN_WIDGET_CTRL(cad, nid, widget->pin.ctrl), cad);
+		}
+		/* Mute/unmute other output associations (e.g. external speakers). */
+		hpSwitchHandler(funcGroup, nid, res);
+		if (!assocs[assocNum].dirty) {
+			SwitchHandlerRename(funcGroup, nid, assocNum, res);
+		}
+		assocs[assocNum].dirty |= res;
+	}
 }
 
 /*

--- a/tranc/Parser.cpp
+++ b/tranc/Parser.cpp
@@ -4825,6 +4825,47 @@ void VoodooHDADevice::switchHandler(FunctionGroup *funcGroup, bool first)
 		}
 		assocs[assocNum].dirty |= res;
 	}
+	/* Handle HP_OUT pins in standalone associations (hpredir < 0):
+	 * read presence detection and update HPHN_ENABLE so that macOS does
+	 * not select disconnected headphones as the default output. */
+	for (int nid = funcGroup->startNode; nid < funcGroup->endNode; nid++) {
+		widget = widgetGet(funcGroup, nid);
+		if (!widget || (widget->enable == 0) || (widget->type != HDA_PARAM_AUDIO_WIDGET_CAP_TYPE_PIN_COMPLEX))
+			continue;
+		if (HDA_PARAM_PIN_CAP_PRESENCE_DETECT_CAP(widget->pin.cap) == 0)
+			continue;
+		if ((HDA_CONFIG_DEFAULTCONF_MISC(widget->pin.config) & 1) != 0)
+			continue;
+		if ((widget->pin.config & HDA_CONFIG_DEFAULTCONF_DEVICE_MASK) != HDA_CONFIG_DEFAULTCONF_DEVICE_HP_OUT)
+			continue;
+		assocNum = widget->bindAssoc;
+		if (assocs[assocNum].hpredir >= 0)
+			continue; /* already handled by the main loop above */
+		res = sendCommand(HDA_CMD_GET_PIN_SENSE(cad, nid), cad);
+		res = HDA_CMD_GET_PIN_SENSE_PRESENCE_DETECT(res);
+		if (funcGroup->audio.quirks & HDA_QUIRK_SENSEINV)
+			res ^= 1;
+		if (!first && (widget->sense == res))
+			continue;
+		widget->sense = res;
+		logMsg("HP standalone pin sense: cad %d nid=%d res=%d\n", (int)cad, (int)nid, (int)res);
+		/* Enable headphone amplifier only when headphones are present. */
+		UInt32 val;
+		if (res != 0)
+			val = widget->pin.ctrl | HDA_CMD_SET_PIN_WIDGET_CTRL_HPHN_ENABLE;
+		else
+			val = widget->pin.ctrl & ~HDA_CMD_SET_PIN_WIDGET_CTRL_HPHN_ENABLE;
+		if (val != widget->pin.ctrl) {
+			widget->pin.ctrl = val;
+			sendCommand(HDA_CMD_SET_PIN_WIDGET_CTRL(cad, nid, widget->pin.ctrl), cad);
+		}
+		/* Mute/unmute other output associations (e.g. external speakers). */
+		hpSwitchHandler(funcGroup, nid, res);
+		if (!assocs[assocNum].dirty) {
+			SwitchHandlerRename(funcGroup, nid, assocNum, res);
+		}
+		assocs[assocNum].dirty |= res;
+	}
 }
 
 /*


### PR DESCRIPTION
## Summary

On codecs where the headphone pin is in its own association (`hpredir=-1`, e.g. ALC897 on Gigabyte Z390 AORUS MASTER), `switchHandler` previously skipped it entirely. This left `HPHN_ENABLE` set in the pin control register regardless of whether headphones are physically present. macOS interprets `HPHN_ENABLE` as "headphones connected" and selects that PCM device as the default output on every reboot — even when no headphones are plugged in.

### Root cause (from user dump analysis)
- Codec: Realtek ALC897 (`0x10ec0897`)
- NID 27 (Headphones, front panel): `as=7`, `hpredir=-1` — standalone association, skipped by existing `switchHandler` loop
- NID 20 (External Speaker): `as=1`, separate association
- At init, NID 27 gets `pin ctrl = 0xC0` (`HPHN_ENABLE | OUT_ENABLE`) unconditionally → macOS selects Headphones as default output

### Fix
Add a second loop in `switchHandler` that processes `HP_OUT` pins in standalone associations (`hpredir < 0`):
- Reads actual presence detection from hardware
- Clears `HPHN_ENABLE` when no headphones are inserted → macOS does not see headphones and keeps External Speaker as default
- Sets `HPHN_ENABLE` when headphones are present, and calls `hpSwitchHandler` to mute/unmute other output associations (e.g. external speakers)
- Applied to both `tranc` and `branches/zdev`

## Test plan
- [ ] Boot without headphones connected → External Speaker remains the default output
- [ ] Reboot without headphones → External Speaker still selected, no regression
- [ ] Plug in headphones → Headphones become active, External Speaker muted
- [ ] Unplug headphones → External Speaker restored
- [ ] Boot with headphones connected → Headphones selected as default

🤖 Generated with [Claude Code](https://claude.com/claude-code)