### PR TITLE
HP switch at boot + S/PDIF fallback

### DIFF
--- a/tranc/Parser.cpp
+++ b/tranc/Parser.cpp
@@ -4866,6 +4866,75 @@ void VoodooHDADevice::switchHandler(FunctionGroup *funcGroup, bool first)
 		}
 		assocs[assocNum].dirty |= res;
 	}
+	/* S/PDIF fallback: if no analog output pin detects presence, mute all
+	 * analog outputs so that S/PDIF becomes the only active output.
+	 * When any analog jack is later inserted, the unsolicited handler will
+	 * unmute it normally. */
+	{
+		bool anyAnalogPresent = false;
+		/* Check all analog output pins with presence detection capability. */
+		for (int nid = funcGroup->startNode; nid < funcGroup->endNode; nid++) {
+			widget = widgetGet(funcGroup, nid);
+			if (!widget || (widget->enable == 0) ||
+			    (widget->type != HDA_PARAM_AUDIO_WIDGET_CAP_TYPE_PIN_COMPLEX))
+				continue;
+			int a = widget->bindAssoc;
+			if (a < 0 || a >= funcGroup->audio.numAssocs)
+				continue;
+			if (assocs[a].dir != HDA_CTL_OUT)
+				continue;
+			/* Skip digital (S/PDIF, HDMI) outputs. */
+			UInt32 devType = widget->pin.config & HDA_CONFIG_DEFAULTCONF_DEVICE_MASK;
+			if (devType == HDA_CONFIG_DEFAULTCONF_DEVICE_SPDIF_OUT ||
+			    devType == HDA_CONFIG_DEFAULTCONF_DEVICE_DIGITAL_OTHER_OUT)
+				continue;
+			if (HDA_PARAM_PIN_CAP_PRESENCE_DETECT_CAP(widget->pin.cap) == 0)
+				continue;
+			if ((HDA_CONFIG_DEFAULTCONF_MISC(widget->pin.config) & 1) != 0)
+				continue;
+			res = sendCommand(HDA_CMD_GET_PIN_SENSE(cad, nid), cad);
+			res = HDA_CMD_GET_PIN_SENSE_PRESENCE_DETECT(res);
+			if (funcGroup->audio.quirks & HDA_QUIRK_SENSEINV)
+				res ^= 1;
+			if (res) {
+				anyAnalogPresent = true;
+				break;
+			}
+		}
+		if (!anyAnalogPresent) {
+			logMsg("No analog output jack detected — muting analog, S/PDIF remains active\n");
+			for (int nid = funcGroup->startNode; nid < funcGroup->endNode; nid++) {
+				widget = widgetGet(funcGroup, nid);
+				if (!widget || (widget->enable == 0) ||
+				    (widget->type != HDA_PARAM_AUDIO_WIDGET_CAP_TYPE_PIN_COMPLEX))
+					continue;
+				int a = widget->bindAssoc;
+				if (a < 0 || a >= funcGroup->audio.numAssocs)
+					continue;
+				if (assocs[a].dir != HDA_CTL_OUT)
+					continue;
+				UInt32 devType = widget->pin.config & HDA_CONFIG_DEFAULTCONF_DEVICE_MASK;
+				if (devType == HDA_CONFIG_DEFAULTCONF_DEVICE_SPDIF_OUT ||
+				    devType == HDA_CONFIG_DEFAULTCONF_DEVICE_DIGITAL_OTHER_OUT)
+					continue;
+				/* Disable analog output pin. */
+				UInt32 val = widget->pin.ctrl &
+					~(HDA_CMD_SET_PIN_WIDGET_CTRL_OUT_ENABLE |
+					  HDA_CMD_SET_PIN_WIDGET_CTRL_HPHN_ENABLE);
+				if (val != widget->pin.ctrl) {
+					widget->pin.ctrl = val;
+					sendCommand(HDA_CMD_SET_PIN_WIDGET_CTRL(cad, nid, widget->pin.ctrl), cad);
+				}
+				/* Mute the pin's output amplifier if available. */
+				AudioControl *ctl = audioCtlAmpGet(funcGroup, nid, HDA_CTL_IN, -1, 1);
+				if (ctl && ctl->mute && !ctl->forcemute) {
+					ctl->forcemute = 1;
+					audioCtlAmpSet(ctl, HDA_AMP_MUTE_DEFAULT,
+						       HDA_AMP_VOL_DEFAULT, HDA_AMP_VOL_DEFAULT);
+				}
+			}
+		}
+	}
 }
 
 /*
@@ -4929,13 +4998,37 @@ void VoodooHDADevice::switchInit(FunctionGroup *funcGroup)
     hdaa_eld_handler(widget);
 
 	}
+	/* Handle HP_OUT pins in standalone associations (hpredir < 0).
+	 * These are skipped by the loop above but still need unsolicited response
+	 * registration and sense initialisation so that switchHandler is called
+	 * at boot and on jack events, allowing HPHN_ENABLE to be managed. */
+	for (int j = funcGroup->startNode; j < funcGroup->endNode; j++) {
+		Widget *widget = widgetGet(funcGroup, j);
+		if (!widget || (widget->enable == 0) || (widget->type != HDA_PARAM_AUDIO_WIDGET_CAP_TYPE_PIN_COMPLEX))
+			continue;
+		if ((HDA_PARAM_PIN_CAP_PRESENCE_DETECT_CAP(widget->pin.cap) == 0) ||
+		    ((HDA_CONFIG_DEFAULTCONF_MISC(widget->pin.config) & 1) != 0))
+			continue;
+		if (assocs[widget->bindAssoc].hpredir >= 0)
+			continue; /* already handled by the loop above */
+		if ((widget->pin.config & HDA_CONFIG_DEFAULTCONF_DEVICE_MASK) != HDA_CONFIG_DEFAULTCONF_DEVICE_HP_OUT)
+			continue;
+		enable = 1;
+		if (HDA_PARAM_AUDIO_WIDGET_CAP_UNSOL_CAP(widget->params.widgetCap)) {
+			sendCommand(HDA_CMD_SET_UNSOLICITED_RESPONSE(cad, j,
+					HDA_CMD_SET_UNSOLICITED_RESPONSE_ENABLE | HDAC_UNSOLTAG_EVENT_HP), cad);
+		}
+		int res = sendCommand(HDA_CMD_GET_PIN_SENSE(cad, j), cad);
+		res = HDA_CMD_GET_PIN_SENSE_PRESENCE_DETECT(res);
+		if (funcGroup->audio.quirks & HDA_QUIRK_SENSEINV)
+			res ^= 1;
+		widget->sense = res;
+		logMsg("Enabling HP standalone output switching at node %d\n", j);
+	}
 	funcGroup->mSwitchEnable = enable;
-/*	if (enable) {
-			//switchHandler(funcGroup, true);
-		
-		if (poll)
-			errorMsg("XXX\nXXX: poll based jack detection unimplemented\nXXX\n");
-	}*/
+	if (enable) {
+		switchHandler(funcGroup, true);
+	}
 }
 
 void VoodooHDADevice::hdaa_eld_handler(Widget *widget)


### PR DESCRIPTION
## Summary

- **HP switch at boot**: `switchHandler(funcGroup, true)` was commented out in `switchInit()` — headphone presence detection at startup never triggered speaker muting. Also adds registration of unsolicited events for standalone HP_OUT pins (`hpredir < 0`).
- **S/PDIF fallback**: when no analog output pin detects a jack at boot, all analog outputs are muted (OUT_ENABLE + HPHN_ENABLE disabled, amplifiers force-muted). S/PDIF remains the only active output. Analog outputs are re-enabled normally when a jack is inserted later.

## Problem

1. **HP at boot**: With headphones plugged in at boot, both headphones and speakers were active — `switchInit()` registered unsolicited events but never called `switchHandler()` to process the initial pin state.

2. **S/PDIF fallback**: When only optical (S/PDIF) is connected and no analog jacks are plugged in, all analog outputs were still enabled and the first analog PCM device was the default — sending audio to empty jacks instead of S/PDIF.

## Changes

`switchInit()` (Parser.cpp):
- Add second loop to handle standalone HP_OUT pins with presence detection
- Uncomment `switchHandler(funcGroup, true)` call

`switchHandler()` (Parser.cpp):
- Add third pass after HP standalone handling: check presence on all analog output pins with PDC, if none detected → mute all analog outputs

## Test plan

- [ ] Boot with headphones plugged in → speakers should be muted
- [ ] Boot with only S/PDIF connected (no analog jacks) → analog outputs muted, S/PDIF active
- [ ] Boot with speakers plugged in → normal operation
- [ ] Hot-plug headphones after boot → speakers mute, HP activates
- [ ] Hot-plug analog jack after S/PDIF-only boot → analog re-enables

🤖 Generated with [Claude Code](https://claude.com/claude-code)